### PR TITLE
Update Gruntfile.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -45,7 +45,7 @@ module.exports = function(grunt) {
             port:  9000,
             hostname: 'localhost',
             livereload: 35729,
-            open:'http://<%= connect.options.hostname %>:<%= connect.options.port %>?baseApiUrl=https://demo.openmf.org'            
+            open:'http://<%= connect.options.hostname %>:<%= connect.options.port %>?baseApiUrl=https://demo.openmf.org'
         },
         livereload: {
             options: {


### PR DESCRIPTION
[4mGruntfile.js[24m
  [90mline 48[39m   [90mcol 121[39m  [34mTrailing whitespace.[39m

I installed the community-app and when I validated it (using **_grunt validate_**), I saw multiple errors in the **_jshint-log.xml_** file. The first error was the trailing whitespace in the Gruntfile.js so I modified that. 